### PR TITLE
ignore the client player name in checkPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,4 @@ Since the new Video from TheMisterEpic we need more Secure LAN Worlds
 
 Built for those who want tighter control and stronger security without sacrificing performance, this mod lets you manage your Minecraft world like a pro.
 
-Don’t forget to whitelist yourself! 😉
 Take your LAN Minecraft experience to the next level with this powerful whitelist mod! Now, for the first time, you can enable a whitelist in your solo worlds — giving you complete control over who can join, even when playing offline.

--- a/src/client/java/net/ovilli/whitelistsingelplayer/client/WhitelistsingelplayerClient.java
+++ b/src/client/java/net/ovilli/whitelistsingelplayer/client/WhitelistsingelplayerClient.java
@@ -1,10 +1,15 @@
 package net.ovilli.whitelistsingelplayer.client;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.minecraft.client.MinecraftClient;
+import net.ovilli.whitelistsingelplayer.Whitelistsingelplayer;
 
 public class WhitelistsingelplayerClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
+        Whitelistsingelplayer.setClientName(
+            MinecraftClient.getInstance().getSession().getUsername()
+        );
     }
 }

--- a/src/main/java/net/ovilli/whitelistsingelplayer/Whitelistsingelplayer.java
+++ b/src/main/java/net/ovilli/whitelistsingelplayer/Whitelistsingelplayer.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 public class Whitelistsingelplayer implements ModInitializer{
 
+    private static String CLIENT_NAME;
+    private static boolean CLIENT_NAME_SET = false;
     public static final Set<String> WHITELIST = new HashSet<>();
     public static Path CONFIG_DIR;
 
@@ -39,6 +41,16 @@ public class Whitelistsingelplayer implements ModInitializer{
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
             checkPlayer(newPlayer);
         });
+    }
+
+    public static void setClientName(String name) {
+        if (CLIENT_NAME_SET) {
+            throw new IllegalStateException(
+                "CLIENT_NAME can only be set once (by the client init function)!"
+            );
+        }
+        CLIENT_NAME = name;
+        CLIENT_NAME_SET = true;
     }
 
     private void loadWhitelist() {
@@ -66,7 +78,7 @@ public class Whitelistsingelplayer implements ModInitializer{
 
     private void checkPlayer(ServerPlayerEntity player) {
         String name = player.getGameProfile().getName();
-        if (!WHITELIST.contains(name)) {
+        if (!CLIENT_NAME.equals(name) && !WHITELIST.contains(name)) {
             player.networkHandler.disconnect(Text.of("You are not allowed to join this server."));
         }
     }


### PR DESCRIPTION
I really like this mod as it adds a little more security to LAN worlds, but I think it's weird that you have to add yourself to the whitelist, so I made a small change that makes it so the checkPlayer function doesn't check the whitelist if the connecting player is the client player.
I basically don't know any java so idk if it's any good.
Also it is your project so feel free to reject this if you don't want it.